### PR TITLE
Excude subdomain from action path params

### DIFF
--- a/lib/dox/entities/action.rb
+++ b/lib/dox/entities/action.rb
@@ -30,7 +30,8 @@ module Dox
       end
 
       def path_params
-        @path_params ||= request.path_parameters.symbolize_keys.except(:action, :controller, :format)
+        @path_params ||=
+          request.path_parameters.symbolize_keys.except(:action, :controller, :format, :subdomain)
       end
 
       def template_path_params


### PR DESCRIPTION
When working with subdomains this is needed