### PR TITLE
Pass raw params in Action DSL

### DIFF
--- a/lib/dox/dsl/action.rb
+++ b/lib/dox/dsl/action.rb
@@ -22,7 +22,7 @@ module Dox
           action_verb: @verb.presence,
           action_path: @path.presence,
           action_desc: @desc.presence,
-          action_params: @params.presence
+          action_params: @params
         }
       end
     end


### PR DESCRIPTION
Currently, a user cannot override custom params used in the controller and not display them in the API documentation.

This PR enables passing an empty hash to the Action DSL.