### PR TITLE
Add require for forwardable lib

### DIFF
--- a/lib/dox/formatter.rb
+++ b/lib/dox/formatter.rb
@@ -1,6 +1,7 @@
 require 'rspec/core'
 require 'rspec/core/formatters/base_formatter'
 require 'rspec/core/formatters/console_codes'
+require 'forwardable'
 
 module Dox
   class Formatter < RSpec::Core::Formatters::BaseFormatter


### PR DESCRIPTION
Fix issue [#43](https://github.com/infinum/dox/issues/43) ```Uninitialized constant Dox::Formatter::Forwardable```, as reported in this issue, the solution to this problem would be:

 Editing the gem folder and adding ```require forwardable``` in ```lib/dox/formatter.rb``` seems to solve the problem.