### PR TITLE
Add uninitialized constant to common issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,16 @@ Or you can just take your generated markdown and host your documentation on [Api
 
 You might experience some strange issues when generating the documentation. Here are a few examples of what we've encountered so far.
 
+#### Uninitialized constant errors
+
+There seems to be a problem with **rspec-rails** versions 3.7 and later not automatically requiring the project's rails_helper.rb when run with the `--format` flag.
+
+To fix this issue, generate your documentation with `--require rails_helper`:
+
+```
+bundle exec rspec -f Dox::Formatter --order defined --tag dox --out docs.md --require rails_helper
+```
+
 #### Wrap parameters issue
 Rails wraps JSON parameters on all requests by default, which results with documented requests looking like this:
 


### PR DESCRIPTION
As we've discussed in #43, the problem seems to be within rspec-rails so we might as well add that to README.

I only wrote it as common issue, do you think it should be added to the generate documentation section as well? Since this problem wasn't brought up before, I imagine it's still not strictly necessary to force the requirement for everyone.