### PR TITLE
Removes resource helper. Fixes #52

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,13 +9,14 @@ Change:
 - BREAKING CHANGE Base structure is now defined in .json format
 - BREAKING CHANGE Output is written to a .json file
 - BREAKING CHANGE Html is rendered with Redoc instead of Aglio
-- Renamed Dox.config.desc_folder_path -> Dox.config.descriptions_location
-- Depricated Dox.config.header_file_path
+- Renamed `Dox.config.desc_folder_path` -> `Dox.config.descriptions_location`
+- Depricated `Dox.config.header_file_path`
+- Removed `endpoint` method from document resource block
 
 New:
-- Added Dox.config.title
-- Added Dox.config.header_description
-- Added Dox.config.version
+- Added `Dox.config.title`
+- Added `Dox.config.header_description`
+- Added `Dox.config.version`
 
 ## Version 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -83,7 +83,6 @@ module Docs
       # define common resource data for each action
       document :api do
         resource 'Bids' do
-          endpoint '/bids'
           group 'Bids'
           desc 'bids.md'
         end
@@ -181,7 +180,6 @@ You can omit defining the resource group, if you don't have any description for 
 #### Resource
 Resource contains actions and is defined with:
 - **name** (required)
-- **endpoint** (required)
 - **group** (required; to associate it with the related group)
 - desc (optional; inline string or relative filepath)
 
@@ -189,7 +187,6 @@ Example:
 ``` ruby
 document :bids do
   resource 'Bids' do
-    endpoint '/bids'
     group 'Bids'
     desc 'bids/bids.md'
   end
@@ -205,7 +202,6 @@ document :bids_common do
   end
 
   resource 'Bids' do
-    endpoint '/bids'
     group 'Bids'
     desc 'bids/bids.md'
   end

--- a/lib/dox/dsl/resource.rb
+++ b/lib/dox/dsl/resource.rb
@@ -16,7 +16,6 @@ module Dox
 
         raise(Dox::Errors::InvalidResourceError, 'Resource name is required!') if @name.blank?
         raise(Dox::Errors::InvalidResourceError, 'Resource group is required!') if @group.blank?
-        raise(Dox::Errors::InvalidResourceError, 'Resource endpoint is required!') if @endpoint.blank?
       end
 
       def config
@@ -24,7 +23,6 @@ module Dox
           resource_name: @name.presence,
           resource_desc: @desc.presence,
           resource_group_name: @group.presence,
-          resource_endpoint: @endpoint.presence,
           apidoc: true
         }
       end

--- a/lib/dox/entities/resource.rb
+++ b/lib/dox/entities/resource.rb
@@ -1,14 +1,13 @@
 module Dox
   module Entities
     class Resource
-      attr_reader :name, :desc, :endpoint, :group
+      attr_reader :name, :desc, :group
       attr_accessor :actions
 
       def initialize(details)
         @name = details[:resource_name]
         @group = details[:resource_group_name]
         @desc = details[:resource_desc]
-        @endpoint = details[:resource_endpoint]
         @actions = {}
       end
     end

--- a/spec/dsl/resource_spec.rb
+++ b/spec/dsl/resource_spec.rb
@@ -3,27 +3,17 @@ describe Dox::DSL::Resource do
 
   RESOURCE_NAME = 'Pokemons'.freeze
   RESOURCE_GROUP = 'Pokemons'.freeze
-  RESOURCE_ENDPOINT = '/pokemons'.freeze
   RESOURCE_DESC = 'Returns list of Pokemons'.freeze
 
   let(:options) do
     proc do
       group RESOURCE_GROUP
-      endpoint RESOURCE_ENDPOINT
       desc RESOURCE_DESC
     end
   end
 
   let(:options_without_group) do
     proc do
-      endpoint RESOURCE_ENDPOINT
-      desc RESOURCE_DESC
-    end
-  end
-
-  let(:options_without_endpoint) do
-    proc do
-      group RESOURCE_GROUP
       desc RESOURCE_DESC
     end
   end
@@ -41,12 +31,6 @@ describe Dox::DSL::Resource do
           subject.new(RESOURCE_NAME, &options_without_group)
         end.to raise_error(Dox::Errors::InvalidResourceError, /group is required/)
       end
-
-      it 'raises error when endpoint is not specified' do
-        expect do
-          subject.new(RESOURCE_NAME, &options_without_endpoint)
-        end.to raise_error(Dox::Errors::InvalidResourceError, /endpoint is required/)
-      end
     end
 
     context 'when required attributes present' do
@@ -62,7 +46,6 @@ describe Dox::DSL::Resource do
     let(:resource) { subject.new(RESOURCE_NAME, &options) }
     it { expect(resource.config[:resource_name]).to eq(RESOURCE_NAME) }
     it { expect(resource.config[:resource_group_name]).to eq(RESOURCE_GROUP) }
-    it { expect(resource.config[:resource_endpoint]).to eq(RESOURCE_ENDPOINT) }
     it { expect(resource.config[:resource_desc]).to eq(RESOURCE_DESC) }
   end
 end

--- a/spec/dsl_spec.rb
+++ b/spec/dsl_spec.rb
@@ -6,7 +6,6 @@ describe Dox::DSL::Documentation do
       {
         apidoc: true,
         resource_desc: nil,
-        resource_endpoint: '/pokemons',
         resource_group_desc: 'Pokemons group desc',
         resource_group_name: 'Pokemons',
         resource_name: 'Pokemons'
@@ -24,7 +23,6 @@ describe Dox::DSL::Documentation do
         {
           apidoc: true,
           resource_desc: nil,
-          resource_endpoint: '/pokemons',
           resource_group_desc: 'Pokemons group desc',
           resource_group_name: 'Pokemons',
           resource_name: 'Pokemons',
@@ -50,7 +48,6 @@ describe Dox::DSL::Documentation do
         {
           apidoc: true,
           resource_desc: nil,
-          resource_endpoint: '/pokemons',
           resource_group_desc: 'Pokemons group desc',
           resource_group_name: 'Pokemons',
           resource_name: 'Pokemons',

--- a/spec/entities/resource_spec.rb
+++ b/spec/entities/resource_spec.rb
@@ -4,8 +4,7 @@ describe Dox::Entities::Resource do
   let(:details) do
     {
       resource_name: 'Pokemons',
-      resource_desc: 'Pokemons',
-      resource_endpoint: '/pokemons'
+      resource_desc: 'Pokemons'
     }
   end
 
@@ -17,10 +16,6 @@ describe Dox::Entities::Resource do
 
   describe '#desc' do
     it { expect(resource.desc).to eq(details[:resource_desc]) }
-  end
-
-  describe '#endpoint' do
-    it { expect(resource.endpoint).to eq(details[:resource_endpoint]) }
   end
 
   describe '#actions' do

--- a/spec/fixtures/dox_dsl_test_classes.rb
+++ b/spec/fixtures/dox_dsl_test_classes.rb
@@ -29,7 +29,6 @@ module Pokemons
     end
 
     resource 'Pokemons' do
-      endpoint '/pokemons'
       group 'Pokemons'
     end
   end

--- a/spec/formatter_spec.rb
+++ b/spec/formatter_spec.rb
@@ -16,7 +16,6 @@ describe Dox::Formatter do
         dox: true,
         resource_group_name: 'Pokemons & Digimons',
         resource_name: 'Pokemons',
-        resource_endpoint: '/pokemons',
         action_name: 'Get pokemon',
         description: 'returns pokemon'
       },
@@ -50,7 +49,6 @@ describe Dox::Formatter do
         dox: true,
         resource_group_name: 'Pokemons & Digimons',
         resource_name: 'Pokemons',
-        resource_endpoint: '/pokemons',
         action_name: 'Create pokemon',
         description: 'creates pokemon'
       },
@@ -91,7 +89,6 @@ describe Dox::Formatter do
         dox: true,
         resource_group_name: 'Pokemons & Digimons',
         resource_name: 'Digimons',
-        resource_endpoint: '/digimons',
         action_name: 'Get digimons',
         action_desc: 'Returns all digimons',
         description: 'returns digimons'
@@ -134,7 +131,6 @@ describe Dox::Formatter do
         dox: true,
         resource_group_name: 'Auth',
         resource_name: 'Auth',
-        resource_endpoint: '/auth',
         action_name: 'Auth',
         action_desc: 'Auth',
         description: 'Auth'

--- a/spec/printers/resource_group_printer_spec.rb
+++ b/spec/printers/resource_group_printer_spec.rb
@@ -24,8 +24,7 @@ describe Dox::Printers::ResourceGroupPrinter do
       let(:resource_details) do
         {
           resource_name: 'Pokemons',
-          resource_desc: 'Pokemons',
-          resource_endpoint: '/pokemons'
+          resource_desc: 'Pokemons'
         }
       end
       let(:resource) { Dox::Entities::Resource.new(resource_details) }

--- a/spec/printers/resource_printer_spec.rb
+++ b/spec/printers/resource_printer_spec.rb
@@ -5,7 +5,6 @@ describe Dox::Printers::ResourcePrinter do
     {
       resource_name: 'Pokemons',
       resource_desc: 'pokemons.md',
-      resource_endpoint: '/pokemons',
       resource_group_name: 'Beings'
     }
   end


### PR DESCRIPTION
Endpoint is not needed by openapi standard. Its already included in the `path`