### PR TITLE
Depend on ActiveSupport specifically, not all of Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gemspec
 
 rails_version = ENV['RAILS_VERSION'] || '6.0.2'
 
-gem 'rails', "~> #{rails_version}"
+gem 'activesupport', "~> #{rails_version}"

--- a/dox.gemspec
+++ b/dox.gemspec
@@ -25,13 +25,13 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_runtime_dependency 'activesupport', '>= 4.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'json'
   spec.add_development_dependency 'pry-nav'
   spec.add_development_dependency 'pry-rails'
   spec.add_development_dependency 'pry-stack_explorer'
-  spec.add_runtime_dependency 'rails', '>= 4.0'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'


### PR DESCRIPTION
As best I can tell, the only "rails" requires are for activesupport.
https://github.com/infinum/dox/blob/85ae8a3d797156d0b3b10c5225fc14c2a13f70d4/lib/dox.rb#L1-L2

Rails itself (no railties or engines or anything) is ever actually required.
Therefore, only activesupport should be marked as the runtime dependency.
This enables users to depend on dox without pulling in all of rails if they so choose.

This was initially detected as an issue when we changed our app to pull in the various rails gems individually, so as to avoid activestorage as a dep;
(thanks to https://github.com/rails/rails/issues/41750)

We had to remove dox for the time being because it was forcing rails to be installed; and therefore forcing activestorage to be installed.