### PR TITLE
Use #media_type & #content_type as fallback

### DIFF
--- a/lib/dox/entities/example.rb
+++ b/lib/dox/entities/example.rb
@@ -5,10 +5,8 @@ module Dox
 
       attr_reader :desc, :name, :request_schema, :response_schema_success, :response_schema_fail
 
-      def_delegator :response, :status, :response_status
-      def_delegator :response, :content_type, :response_content_type
-      def_delegator :request, :content_type, :request_content_type
       def_delegator :request, :method, :request_method
+      def_delegator :response, :status, :response_status
 
       def initialize(details, request, response)
         @desc = details[:description]
@@ -51,6 +49,15 @@ module Dox
         else
           request_path
         end
+      end
+
+      # Rails 7 changes content_type result
+      def request_content_type
+        request.respond_to?(:media_type) ? request.media_type : request.content_type
+      end
+
+      def response_content_type
+        response.respond_to?(:media_type) ? response.media_type : response.content_type
       end
 
       private


### PR DESCRIPTION
When running dox to generate the API documentation on Rails 7 applications, the following error is displayed:

```bash
DEPRECATION WARNING: Rails 7.1 will return Content-Type header without modification. If you want just the MIME type, please use `#media_type` instead. (called from request_content_type at /Users/cilim/.rbenv/versions/3.0.3/lib/ruby/3.0.0/forwardable.rb:238)
```

This is caused by using the `#content_type` method on request and response objects. We indeed only need the mime type.