### PR TITLE
Enable descriptions_location to be an array of pathnames

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Set these optional options in the rails_helper:
 
 | Option | Value | Description |
 | -- | -- | -- |
-| descriptions_location | Pathname instance or fullpath string | Folder containing markdown descriptions of resources. |
+| descriptions_location | Pathname instance or fullpath string (can be an array) | Folder containing markdown descriptions of resources. |
 | schema_request_folder_path | Pathname instance or fullpath string | Folder with request schemas of resources. |
 | schema_response_folder_path | Pathname instance or fullpath string | Folder with response schemas of resources. |
 | schema_response_fail_file_path | Pathname instance or fullpath string | Json file that contains the default schema of a failed response. |

--- a/lib/dox/config.rb
+++ b/lib/dox/config.rb
@@ -12,9 +12,11 @@ module Dox
     attr_reader :descriptions_location
 
     def descriptions_location=(folder_path)
-      raise(Errors::FolderNotFoundError, folder_path) unless Dir.exist?(folder_path)
+      Array(folder_path).each do |path|
+        raise(Errors::FolderNotFoundError, path) unless Dir.exist?(path)
+      end
 
-      @descriptions_location = folder_path
+      @descriptions_location = Array(folder_path)
     end
 
     def schema_request_folder_path=(folder_path)

--- a/lib/dox/printers/base_printer.rb
+++ b/lib/dox/printers/base_printer.rb
@@ -19,10 +19,15 @@ module Dox
         hash[key] = default
       end
 
-      def read_file(path, root_path: Dox.config.descriptions_location)
-        return '' unless root_path
+      def read_file(path, config_root_path: Dox.config.descriptions_location)
+        return '' unless config_root_path
 
-        File.read(File.join(root_path, path))
+        config_root_path.each do |root_path|
+          file_path = File.join(root_path, path)
+          next unless File.exist?(file_path)
+
+          return File.read(file_path)
+        end
       end
 
       def formatted_body(body_str, content_type)

--- a/spec/config_spec.rb
+++ b/spec/config_spec.rb
@@ -12,7 +12,26 @@ describe Dox::Config do
 
     it 'sets the attribute when the folder exists' do
       config.desc_folder_path = 'spec/printers'
-      expect(config.descriptions_location).to eq('spec/printers')
+      expect(config.descriptions_location).to eq(['spec/printers'])
+    end
+
+    context 'when attribute is an array' do
+      context 'when one of the folders in array are missing' do
+        it 'raises an error' do
+          expect do
+            config.descriptions_location = ['spec/printers', 'spec/mydir']
+          end.to raise_error(Dox::Errors::FolderNotFoundError, 'spec/mydir')
+        end
+      end
+
+      context 'when all folders in array are present' do
+        it 'sets the attribute value to the array' do
+          expected_array = ['spec/printers', 'spec/formatters']
+          config.desc_folder_path = expected_array
+
+          expect(config.descriptions_location).to eq(expected_array)
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
### Problem

We have a case on a project where we can't keep a description of a resource in the default folder where all the other resource descriptions are kept.

### Solution

This PR enables the developer to set the `descriptions_location` config to be an **array** of pathnames. When dox is in the process of creating the description content for each resource, it will lookup all of the pathnames in the array.