### PR TITLE
Raise error in Resource if desc MD present, but file missing

### DIFF
--- a/lib/dox.rb
+++ b/lib/dox.rb
@@ -32,6 +32,7 @@ require 'dox/printers/example_response_printer'
 require 'dox/printers/resource_group_printer'
 require 'dox/printers/resource_printer'
 require 'dox/util/http'
+require 'dox/util/file'
 require 'dox/version'
 
 module Dox

--- a/lib/dox/dsl/resource.rb
+++ b/lib/dox/dsl/resource.rb
@@ -16,6 +16,7 @@ module Dox
 
         raise(Dox::Errors::InvalidResourceError, 'Resource name is required!') if @name.blank?
         raise(Dox::Errors::InvalidResourceError, 'Resource group is required!') if @group.blank?
+        raise(Dox::Errors::InvalidResourceError, "Resource desc #{@desc} is missing!") if desc_file_path.nil?
       end
 
       def config
@@ -25,6 +26,14 @@ module Dox
           resource_group_name: @group.presence,
           apidoc: true
         }
+      end
+
+      private
+
+      def desc_file_path
+        return true if @desc.nil? || !@desc.end_with?('.md')
+
+        Util::File.file_path(@desc).presence
       end
     end
   end

--- a/lib/dox/printers/base_printer.rb
+++ b/lib/dox/printers/base_printer.rb
@@ -20,14 +20,9 @@ module Dox
       end
 
       def read_file(path, config_root_path: Dox.config.descriptions_location)
-        return '' unless config_root_path
+        full_path = Util::File.file_path(path, config_root_path: config_root_path)
 
-        config_root_path.each do |root_path|
-          file_path = File.join(root_path, path)
-          next unless File.exist?(file_path)
-
-          return File.read(file_path)
-        end
+        full_path.nil? ? nil : File.read(full_path)
       end
 
       def formatted_body(body_str, content_type)

--- a/lib/dox/util/file.rb
+++ b/lib/dox/util/file.rb
@@ -1,0 +1,18 @@
+module Dox
+  module Util
+    module File
+      def self.file_path(path, config_root_path: Dox.config.descriptions_location)
+        return '' unless config_root_path
+
+        config_root_path.each do |root_path|
+          full_path = ::File.join(root_path, path)
+          next unless ::File.exist?(full_path)
+
+          return full_path
+        end
+
+        nil
+      end
+    end
+  end
+end

--- a/spec/dsl/resource_spec.rb
+++ b/spec/dsl/resource_spec.rb
@@ -40,6 +40,30 @@ describe Dox::DSL::Resource do
         end.not_to raise_error
       end
     end
+
+    context 'when desc is a file that does not exist' do
+      it 'raises error when name is not specified' do
+        expect do
+          subject.new(RESOURCE_NAME) do
+            group RESOURCE_GROUP
+            desc 'unknown_file.md'
+          end
+        end.to raise_error(Dox::Errors::InvalidResourceError, /unknown_file.md is missing/)
+      end
+    end
+
+    context 'when desc is a file that does exist' do
+      it 'initializes resource' do
+        allow(Dox::Util::File).to receive(:file_path).with('known_file.md').and_return('Some text')
+
+        expect do
+          subject.new(RESOURCE_NAME) do
+            group RESOURCE_GROUP
+            desc 'known_file.md'
+          end
+        end.not_to raise_error
+      end
+    end
   end
 
   describe '#config' do


### PR DESCRIPTION
When a Resource is defined like this:

```ruby
module Dox
  module Contracts
    extend DSL::Syntax

    document :api do
      resource 'Contracts' do
        group 'Contracts'
        desc 'contracts.md'
      end
    end
  end
end
```
and the **desc** is pointing to an unexisting MD file, an error is raised:
```bash
TypeError: t.toLowerCase is not a function
    at i.u [as add] (/Users/cilim/.config/yarn/global/node_modules/redoc/bundles/redoc.lib.js:2:8081)
    at oi.add (/Users/cilim/.config/yarn/global/node_modules/redoc/bundles/redoc.lib.js:41:90005)
    at /Users/cilim/.config/yarn/global/node_modules/redoc/bundles/redoc.lib.js:41:89871
    at Array.forEach (<anonymous>)
```

This error is very confusing and it’s difficult to uncover what is wrong. Dox should check each resource validity before running the specs and raise an error notifying the developer that a description file is referenced, but the actual file doesn’t exist.