### PR TITLE
Rewind rack.input before re-parsing the request body for rack 3 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## v3.0.1
+
+### Bug fixes
+
+- Rewind `rack.input` in `Dox::Formatters::Multipart` before re-parsing the request body. Rack 3 dropped the implicit rewind on `Rack::Request#body`, so re-parsing a multipart request whose body had already been consumed by Rails raised `Rack::Multipart::Parser::BoundedIO#read: bad content body (EOFError)` when the formatter ran.
+
 ## v3.0.0
 
 ### Enhancements

--- a/lib/dox/formatters/multipart.rb
+++ b/lib/dox/formatters/multipart.rb
@@ -14,7 +14,13 @@ module Dox
       private
 
       def extracted_multipart
+        rewind_input
         Rack::Multipart.extract_multipart(http_env)
+      end
+
+      def rewind_input
+        body = http_env.body
+        body.rewind if body.respond_to?(:rewind)
       end
 
       attr_reader :http_env

--- a/lib/dox/version.rb
+++ b/lib/dox/version.rb
@@ -1,3 +1,3 @@
 module Dox
-  VERSION = '3.0.0'.freeze
+  VERSION = '3.0.1'.freeze
 end

--- a/spec/formatters/multipart_spec.rb
+++ b/spec/formatters/multipart_spec.rb
@@ -28,5 +28,11 @@ describe Dox::Formatters::Multipart do
 
       expect(Rack::Multipart).to have_received(:extract_multipart).once
     end
+
+    it 'rewinds the input before extracting the multipart body' do
+      body.read
+
+      expect { subject }.to change(body, :pos).to(0)
+    end
   end
 end


### PR DESCRIPTION
## Rack 3 support
Resolves: https://github.com/infinum/dox/issues/67

## Summary

Fixes `Rack::Multipart::Parser::BoundedIO#read: bad content body (EOFError)` raised by `Dox::Formatter` when generating documentation for request specs that post `multipart/form-data` on Rails apps running Rack 3.

## Problem

After upgrading from Rack 2 to Rack 3, running the dox formatter against any multipart request spec crashes at the end of the run: